### PR TITLE
Reject unsupported IP version in Split Routing

### DIFF
--- a/internal/splitrt/filter.go
+++ b/internal/splitrt/filter.go
@@ -89,6 +89,31 @@ table inet oc-daemon-routing {
 		# matches the outgoing interface
 		ct mark $FWMARK counter masquerade
 	}
+
+	chain rejectipversion {
+		# used to reject unsupported ip version on the tunnel device
+
+		# make sure exclude traffic is not filtered
+		ct mark $FWMARK counter accept
+
+		# use tcp reset and icmp admin prohibited
+		meta l4proto tcp counter reject with tcp reset
+		counter reject with icmpx admin-prohibited
+	}
+
+	chain rejectforward {
+		type filter hook forward priority filter; policy accept;
+
+		# reject unsupported ip versions when forwarding packets,
+		# add matching jump rule to rejectipversion if necessary
+	}
+
+	chain rejectoutput {
+		type filter hook output priority filter; policy accept;
+
+		# reject unsupported ip versions when sending packets,
+		# add matching jump rule to rejectipversion if necessary
+	}
 }
 `
 	r := strings.NewReplacer("$FWMARK", FWMark)
@@ -130,6 +155,33 @@ func addLocalAddressesIPv4(device string, addresses []*net.IPNet) {
 // filter non-local traffic to vpn addresses
 func addLocalAddressesIPv6(device string, addresses []*net.IPNet) {
 	addLocalAddresses(device, "ip6", addresses)
+}
+
+// rejectIPVersion adds rules for the tunnel device to reject an unsupported ip
+// version ("ipv6" or "ipv4")
+func rejectIPVersion(device, version string) {
+	nftconf := ""
+	for _, chain := range []string{"rejectforward", "rejectoutput"} {
+		nftconf += fmt.Sprintf("add rule inet oc-daemon-routing %s ",
+			chain)
+		nftconf += fmt.Sprintf("meta oifname %s meta nfproto %s ",
+			device, version)
+		nftconf += "counter jump rejectipversion\n"
+	}
+
+	runNft(nftconf)
+}
+
+// rejectIPv6 adds rules for the tunnel device that reject IPv6 traffic on it;
+// used to avoid sending IPv6 packets over a tunnel that only supports IPv4
+func rejectIPv6(device string) {
+	rejectIPVersion(device, "ipv6")
+}
+
+// rejectIPv4 adds rules for the tunnel device that reject IPv4 traffic on it;
+// used to avoid sending IPv4 packets over a tunnel that only supports IPv6
+func rejectIPv4(device string) {
+	rejectIPVersion(device, "ipv4")
 }
 
 // addExclude adds exclude address to netfilter

--- a/internal/splitrt/splitrt.go
+++ b/internal/splitrt/splitrt.go
@@ -43,6 +43,14 @@ func (s *SplitRouting) setupRouting() {
 	addLocalAddressesIPv4(s.config.Device.Name, []*net.IPNet{ipnet4})
 	addLocalAddressesIPv6(s.config.Device.Name, []*net.IPNet{ipnet6})
 
+	// reject unsupported ip versions on vpn
+	if len(s.config.IPv6.Address) == 0 {
+		rejectIPv6(s.config.Device.Name)
+	}
+	if len(s.config.IPv4.Address) == 0 {
+		rejectIPv4(s.config.Device.Name)
+	}
+
 	// add excludes
 	s.excludes.Start()
 


### PR DESCRIPTION
When redirecting packets over the VPN tunnel, reject IP protocol versions that are not supported on the tunnel device.

Signed-off-by: hwipl <33433250+hwipl@users.noreply.github.com>